### PR TITLE
feat: publish blog posts from markdown content

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,28 @@ IEEE — *October 23, 2024*
 
 ---
 
+### 📓 Publish Obsidian notes as blog posts
+
+1. Create a Markdown file inside `content/blog` with YAML front matter:
+
+   ```markdown
+   ---
+   title: My new note
+   description: A short teaser for the list view.
+   publishedAt: 2025-01-01
+   tags:
+     - Obsidian
+     - AI
+   ---
+   ```
+
+2. Write your content using the same Markdown syntax you already use in Obsidian.
+3. Commit and push — the site will list the new note automatically under **/blog**.
+
+> ✅ Include `publishedAt` so posts are sorted correctly. Add `draft: true` in the front matter to hide a note from the live site.
+
+---
+
 > "Code with purpose. Engineer with empathy. Build with impact."
 
 © 2025 Aditya Mahakali. All rights reserved.

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,0 +1,97 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+import { CustomMDX } from '@/app/components/mdx';
+import { getPostBySlug, getPostSlugs, getPostSummary } from '@/lib/posts';
+
+interface BlogPostPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateStaticParams() {
+  const slugs = getPostSlugs();
+
+  return slugs.map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({ params }: BlogPostPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const summary = getPostSummary(slug);
+
+  if (!summary) {
+    return {};
+  }
+
+  const publishedAt = new Date(summary.publishedAt).toISOString();
+
+  return {
+    title: summary.title,
+    description: summary.description,
+    openGraph: {
+      type: 'article',
+      publishedTime: publishedAt,
+      tags: summary.tags,
+      title: summary.title,
+      description: summary.description,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: summary.title,
+      description: summary.description,
+    },
+  };
+}
+
+export default async function BlogPostPage({ params }: BlogPostPageProps) {
+  const { slug } = await params;
+  const post = await getPostBySlug(slug);
+
+  if (!post) {
+    notFound();
+  }
+
+  const publishedDate = new Date(post.publishedAt);
+  const formattedPublishedDate = publishedDate.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+  return (
+    <article className="mx-auto max-w-3xl space-y-8 py-12">
+      <Link
+        href="/blog"
+        className="inline-flex items-center text-sm font-medium text-indigo-600 transition hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+      >
+        ← Back to all posts
+      </Link>
+      <header className="space-y-4">
+        <h1 className="text-4xl font-semibold leading-tight text-neutral-900 dark:text-neutral-50">
+          {post.title}
+        </h1>
+        <div className="flex flex-wrap items-center gap-3 text-sm text-neutral-600 dark:text-neutral-300">
+          <time dateTime={post.publishedAt}>{formattedPublishedDate}</time>
+          <span aria-hidden="true">•</span>
+          <span>{post.readingTime}</span>
+          {post.tags.length > 0 && (
+            <ul className="flex flex-wrap gap-2">
+              {post.tags.map((tag) => (
+                <li
+                  key={tag}
+                  className="rounded-full bg-indigo-50 px-3 py-1 text-xs font-medium text-indigo-600 dark:bg-indigo-950/40 dark:text-indigo-300"
+                >
+                  #{tag}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </header>
+
+      <div className="prose prose-neutral max-w-none dark:prose-invert">
+        <CustomMDX source={post.content} />
+      </div>
+    </article>
+  );
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,90 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+import { getAllPosts } from '@/lib/posts';
+
+export const metadata: Metadata = {
+  title: 'Blog',
+  description:
+    'Long-form notes and project write-ups, published straight from my Obsidian vault.',
+};
+
+const dateFormatter = new Intl.DateTimeFormat('en', {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+});
+
+export default async function BlogPage() {
+  const posts = await getAllPosts();
+
+  if (posts.length === 0) {
+    return (
+      <section className="mx-auto max-w-3xl space-y-4 py-12">
+        <header className="space-y-2">
+          <h1 className="text-4xl font-semibold tracking-tight">Notes &amp; Essays</h1>
+          <p className="text-lg text-neutral-600 dark:text-neutral-300">
+            Drop Markdown files into <code>content/blog</code> to publish them here.
+          </p>
+        </header>
+        <p className="rounded-lg border border-dashed border-neutral-300 bg-neutral-100 p-6 text-neutral-700 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200">
+          No posts yet. Add a Markdown file with front matter to get started.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="mx-auto max-w-4xl space-y-10 py-12">
+      <header className="space-y-2">
+        <h1 className="text-4xl font-semibold tracking-tight">Notes &amp; Essays</h1>
+        <p className="text-lg text-neutral-600 dark:text-neutral-300">
+          Every article is rendered directly from an Obsidian/Markdown file committed to this repo.
+        </p>
+      </header>
+
+      <div className="space-y-6">
+        {posts.map((post) => (
+          <article
+            key={post.slug}
+            className="group rounded-xl border border-neutral-200 bg-white p-6 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-neutral-800 dark:bg-neutral-900"
+          >
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-baseline sm:justify-between">
+              <div className="space-y-2">
+                <h2 className="text-2xl font-semibold text-neutral-900 dark:text-neutral-100">
+                  <Link
+                    href={`/blog/${post.slug}`}
+                    className="hover:text-indigo-600 focus-visible:text-indigo-600 focus-visible:outline-none"
+                  >
+                    {post.title}
+                  </Link>
+                </h2>
+                {post.description && (
+                  <p className="text-neutral-600 dark:text-neutral-300">{post.description}</p>
+                )}
+              </div>
+              <div className="flex flex-col items-start text-sm text-neutral-500 dark:text-neutral-400 sm:items-end">
+                <time dateTime={post.publishedAt}>
+                  {dateFormatter.format(new Date(post.publishedAt))}
+                </time>
+                <span>{post.readingTime}</span>
+              </div>
+            </div>
+            {post.tags.length > 0 && (
+              <ul className="mt-4 flex flex-wrap gap-2">
+                {post.tags.map((tag) => (
+                  <li
+                    key={tag}
+                    className="rounded-full bg-indigo-50 px-3 py-1 text-xs font-medium text-indigo-600 dark:bg-indigo-950/40 dark:text-indigo-300"
+                  >
+                    #{tag}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/app/components/mdx.tsx
+++ b/app/components/mdx.tsx
@@ -3,18 +3,22 @@ import Image from 'next/image';
 
 import { highlight } from 'sugar-high';
 import React from 'react';
-import { MDXRemote, type MDXRemoteSerializeResult } from 'next-mdx-remote';
-// import MermaidClient from './MermaidClient';
-function Table({ children }) {
-  let rows = children.props.children;
+import { MDXRemote } from 'next-mdx-remote/rsc';
 
-  let headers = rows[0].props.children.map((header, index) => (
+function Table({ children }: { children: any }) {
+  const rows = children?.props?.children ?? [];
+
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return children;
+  }
+
+  const headers = (rows[0]?.props?.children ?? []).map((header: React.ReactNode, index: number) => (
     <th key={index}>{header}</th>
   ));
 
-  let tableRows = rows.slice(1).map((row, index) => (
-    <tr key={index}>
-      {row.props.children.map((cell, cellIndex) => (
+  const tableRows = rows.slice(1).map((row: any, rowIndex: number) => (
+    <tr key={rowIndex}>
+      {(row?.props?.children ?? []).map((cell: React.ReactNode, cellIndex: number) => (
         <td key={cellIndex}>{cell}</td>
       ))}
     </tr>
@@ -30,8 +34,8 @@ function Table({ children }) {
   );
 }
 
-function CustomLink(props) {
-  let href = props.href;
+function CustomLink(props: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
+  const href = props.href ?? '';
 
   if (href.startsWith('/')) {
     return (
@@ -48,18 +52,18 @@ function CustomLink(props) {
   return <a target="_blank" rel="noopener noreferrer" {...props} />;
 }
 
-function RoundedImage(props) {
-  return <Image alt={props.alt} className="rounded-lg" {...props} />;
+function RoundedImage({ alt, className, ...rest }: React.ComponentProps<typeof Image>) {
+  const composedClassName = className ? `rounded-lg ${className}` : 'rounded-lg';
+  return <Image alt={alt ?? ''} className={composedClassName} {...rest} />;
 }
 
-function Code({ children, ...props }) {
-  let codeHTML = highlight(children);
+function Code({ children, ...props }: React.HTMLAttributes<HTMLElement>) {
+  const codeHTML = highlight(String(children));
   return <code dangerouslySetInnerHTML={{ __html: codeHTML }} {...props} />;
 }
 
-function slugify(str) {
-  return str
-    .toString()
+function slugify(value: React.ReactNode): string {
+  return String(value)
     .toLowerCase()
     .trim()
     .replace(/\s+/g, '-')
@@ -68,9 +72,10 @@ function slugify(str) {
     .replace(/\-\-+/g, '-');
 }
 
-function createHeading(level) {
-  const Heading = ({ children }) => {
-    let slug = slugify(children);
+function createHeading(level: number) {
+  const Heading = ({ children }: { children: React.ReactNode }) => {
+    const slug = slugify(children);
+
     return React.createElement(
       `h${level}`,
       { id: slug },
@@ -81,7 +86,7 @@ function createHeading(level) {
           className: 'anchor',
         }),
       ],
-      children
+      children,
     );
   };
 
@@ -90,7 +95,7 @@ function createHeading(level) {
   return Heading;
 }
 
-let components = {
+const components = {
   h1: createHeading(1),
   h2: createHeading(2),
   h3: createHeading(3),
@@ -101,14 +106,15 @@ let components = {
   a: CustomLink,
   code: Code,
   Table,
-  // mermaid: MermaidClient, // Using the dynamically imported Mermaid component here
 };
 
-export function CustomMDX(props) {
-  return (
-    <MDXRemote
-      {...props}
-      components={{ ...components, ...(props.components || {}) }}
-    />
-  );
+interface CustomMDXProps {
+  source: string;
+}
+
+export async function CustomMDX({ source }: CustomMDXProps) {
+  return MDXRemote({
+    source,
+    components,
+  });
 }

--- a/app/components/nav.tsx
+++ b/app/components/nav.tsx
@@ -4,9 +4,9 @@ const navItems = {
   '/': {
     name: 'home',
   },
-  // '/blog': {
-  //   name: 'blog',
-  // },
+  '/blog': {
+    name: 'blog',
+  },
   // 'https://vercel.com/templates/next.js/portfolio-starter-kit': {
   //   name: 'deploy',
   // },

--- a/content/blog/welcome-to-my-notes.md
+++ b/content/blog/welcome-to-my-notes.md
@@ -1,0 +1,32 @@
+---
+title: Welcome to My Notes
+description: Why I publish straight from Obsidian and how these notes stay always up-to-date.
+publishedAt: 2025-01-01
+tags:
+  - Obsidian
+  - Personal Knowledge Base
+---
+
+## Shipping thoughts faster
+
+I have years of ideas trapped inside my personal knowledge base. Until now, turning a note into a polished blog post meant copy-pasting into a CMS, fixing formatting, and rebuilding the site.
+
+This site now reads Markdown directly from my notes folder. When I drop a note into `content/blog`, it becomes a published article.
+
+## Writing with Obsidian
+
+Obsidian already stores my thinking in Markdown. Keeping everything in plain text means:
+
+- I can version notes with Git.
+- Formatting stays consistent between my editor and the website.
+- Images and callouts come along for the ride.
+
+## Publishing workflow
+
+1. Draft and edit notes locally.
+2. Commit the Markdown file alongside the code.
+3. Deploy — the blog page rebuilds and exposes the new article.
+
+> ⚡️ No CMS, no copy-paste, just Markdown.
+
+Happy writing!

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -1,0 +1,344 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const CONTENT_ROOT = path.join(process.cwd(), 'content', 'blog');
+const SUPPORTED_EXTENSIONS = ['.md', '.mdx'];
+
+export interface PostFrontmatter {
+  title?: string;
+  description?: string;
+  summary?: string;
+  publishedAt?: string;
+  date?: string;
+  updatedAt?: string;
+  tags?: unknown;
+  draft?: boolean;
+  [key: string]: unknown;
+}
+
+export interface PostSummary {
+  slug: string;
+  title: string;
+  description: string;
+  publishedAt: string;
+  updatedAt?: string;
+  tags: string[];
+  readingTime: string;
+}
+
+export interface Post extends PostSummary {
+  frontmatter: PostFrontmatter;
+  content: string;
+}
+
+interface RawPost {
+  slug: string;
+  filePath: string;
+  frontmatter: PostFrontmatter;
+  content: string;
+}
+
+interface FrontMatterParseResult {
+  frontmatter: PostFrontmatter;
+  content: string;
+}
+
+const FRONT_MATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+
+export function getPostSlugs(): string[] {
+  if (!fs.existsSync(CONTENT_ROOT)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(CONTENT_ROOT)
+    .filter((file) => SUPPORTED_EXTENSIONS.includes(path.extname(file).toLowerCase()))
+    .map((file) => file.replace(/\.mdx?$/i, ''))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+export function getAllPosts(): PostSummary[] {
+  const slugs = getPostSlugs();
+
+  const posts = slugs
+    .map((slug) => readPost(slug))
+    .filter((value): value is RawPost => value !== null)
+    .filter((post) => !isDraft(post.frontmatter))
+    .map((post) => toSummary(post));
+
+  return posts.sort((a, b) => b.publishedAt.localeCompare(a.publishedAt));
+}
+
+export async function getPostBySlug(slug: string): Promise<Post | null> {
+  const post = readPost(slug);
+
+  if (!post || isDraft(post.frontmatter)) {
+    return null;
+  }
+
+  return {
+    ...toSummary(post),
+    frontmatter: post.frontmatter,
+    content: post.content,
+  };
+}
+
+export function getPostSummary(slug: string): PostSummary | null {
+  const post = readPost(slug);
+
+  if (!post || isDraft(post.frontmatter)) {
+    return null;
+  }
+
+  return toSummary(post);
+}
+
+function readPost(slug: string): RawPost | null {
+  const filePath = resolvePostFilePath(slug);
+
+  if (!filePath) {
+    return null;
+  }
+
+  const fileContents = fs.readFileSync(filePath, 'utf8');
+  const { frontmatter, content } = extractFrontMatter(fileContents);
+
+  return {
+    slug,
+    filePath,
+    frontmatter,
+    content,
+  };
+}
+
+function resolvePostFilePath(slug: string): string | null {
+  const baseName = slug.replace(/\.mdx?$/i, '');
+
+  for (const extension of SUPPORTED_EXTENSIONS) {
+    const filePath = path.join(CONTENT_ROOT, `${baseName}${extension}`);
+    if (fs.existsSync(filePath)) {
+      return filePath;
+    }
+  }
+
+  return null;
+}
+
+function toSummary(post: RawPost): PostSummary {
+  const title = typeof post.frontmatter.title === 'string'
+    ? post.frontmatter.title
+    : startCaseFromSlug(post.slug);
+
+  const description = pickDescription(post.frontmatter);
+  const tags = normaliseTags(post.frontmatter.tags);
+  const publishedAt = resolvePublishedDate(post.frontmatter, post.filePath);
+  const updatedAt = resolveUpdatedDate(post.frontmatter);
+  const readingTime = estimateReadingTime(post.content);
+
+  return {
+    slug: post.slug,
+    title,
+    description,
+    tags,
+    publishedAt,
+    updatedAt,
+    readingTime,
+  };
+}
+
+function pickDescription(frontmatter: PostFrontmatter): string {
+  if (typeof frontmatter.description === 'string') {
+    return frontmatter.description;
+  }
+
+  if (typeof frontmatter.summary === 'string') {
+    return frontmatter.summary;
+  }
+
+  return '';
+}
+
+function normaliseTags(tags: PostFrontmatter['tags']): string[] {
+  if (!Array.isArray(tags)) {
+    return [];
+  }
+
+  return tags
+    .map((tag) => (typeof tag === 'string' ? tag : null))
+    .filter((tag): tag is string => tag !== null);
+}
+
+function resolvePublishedDate(frontmatter: PostFrontmatter, filePath: string): string {
+  const candidate =
+    typeof frontmatter.publishedAt === 'string'
+      ? frontmatter.publishedAt
+      : typeof frontmatter.date === 'string'
+        ? frontmatter.date
+        : undefined;
+
+  const parsed = parseDate(candidate);
+
+  if (parsed) {
+    return parsed.toISOString();
+  }
+
+  const stats = fs.statSync(filePath);
+  return stats.birthtime.toISOString();
+}
+
+function resolveUpdatedDate(frontmatter: PostFrontmatter): string | undefined {
+  const parsed = parseDate(frontmatter.updatedAt);
+  return parsed?.toISOString();
+}
+
+function parseDate(value: unknown): Date | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  const timestamp = Date.parse(trimmed);
+
+  if (Number.isNaN(timestamp)) {
+    return null;
+  }
+
+  return new Date(timestamp);
+}
+
+function estimateReadingTime(content: string): string {
+  const words = content
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean).length;
+
+  const averageWordsPerMinute = 200;
+  const minutes = Math.max(1, Math.round(words / averageWordsPerMinute));
+
+  return `${minutes} min read`;
+}
+
+function startCaseFromSlug(slug: string): string {
+  return slug
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function isDraft(frontmatter: PostFrontmatter): boolean {
+  return frontmatter.draft === true;
+}
+
+function extractFrontMatter(source: string): FrontMatterParseResult {
+  const match = source.match(FRONT_MATTER_REGEX);
+
+  if (!match) {
+    return { frontmatter: {}, content: source.trimStart() };
+  }
+
+  const [, frontMatterBlock] = match;
+  const content = source.slice(match[0].length);
+  const frontmatter = parseFrontMatterBlock(frontMatterBlock);
+
+  return {
+    frontmatter,
+    content: content.trimStart(),
+  };
+}
+
+function parseFrontMatterBlock(block: string): PostFrontmatter {
+  const result: PostFrontmatter = {};
+  const lines = block.split(/\r?\n/);
+  let currentKey: string | null = null;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+
+    if (!line || line.startsWith('#')) {
+      continue;
+    }
+
+    const arrayItemMatch = line.match(/^-\s*(.+)$/);
+
+    if (arrayItemMatch && currentKey) {
+      const value = parseScalar(arrayItemMatch[1]);
+      const existing = result[currentKey];
+
+      if (Array.isArray(existing)) {
+        existing.push(value);
+      } else {
+        result[currentKey] = [value];
+      }
+
+      continue;
+    }
+
+    const keyValueMatch = line.match(/^([A-Za-z0-9_-]+)\s*:\s*(.*)$/);
+
+    if (!keyValueMatch) {
+      currentKey = null;
+      continue;
+    }
+
+    const [, key, value] = keyValueMatch;
+
+    if (value === '') {
+      result[key] = [];
+      currentKey = key;
+      continue;
+    }
+
+    result[key] = parseScalar(value);
+    currentKey = key;
+  }
+
+  return result;
+}
+
+function parseScalar(value: string): unknown {
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return '';
+  }
+
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+    const list = trimmed.slice(1, -1).split(',');
+    return list
+      .map((item) => item.trim())
+      .filter(Boolean)
+      .map((item) => removeWrappingQuotes(item));
+  }
+
+  if (trimmed === 'true') {
+    return true;
+  }
+
+  if (trimmed === 'false') {
+    return false;
+  }
+
+  const maybeNumber = Number(trimmed);
+  if (!Number.isNaN(maybeNumber)) {
+    return maybeNumber;
+  }
+
+  return removeWrappingQuotes(trimmed);
+}
+
+function removeWrappingQuotes(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+
+  return value;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,9 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    },
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
## Summary
- add a reusable posts library that reads markdown files, parses front matter, and exposes post metadata for the app
- create Blog index and individual post routes that render markdown content with custom MDX components
- document the workflow for dropping Obsidian notes into `content/blog` and expose the section in site navigation

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e7df73a9a4832eba205eec47c4636d