### PR TITLE
Add homepage link to blog

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import {
 } from "react-icons/fa";
 import { SiLeetcode } from "react-icons/si";
 import Image from "next/image";
+import Link from "next/link";
 import pp from "./images/dp.jpeg";
 
 export default function Page() {
@@ -83,6 +84,12 @@ export default function Page() {
                 >
                   Download Resume
                 </a>
+                <Link
+                  href="/blog"
+                  className="bg-blue-600 hover:bg-blue-500 text-white py-2 px-4 rounded-lg font-medium"
+                >
+                  Visit Blog
+                </Link>
               </div>
             </div>
           </div>

--- a/content/blog/ai-agents-architecture-patterns.md
+++ b/content/blog/ai-agents-architecture-patterns.md
@@ -1,0 +1,53 @@
+---
+title: Patterns for Building Reliable AI Agents
+description: A practical look at the design tradeoffs behind orchestrating autonomous AI agents that deliver useful work.
+publishedAt: 2024-06-20
+tags:
+  - AI Agents
+  - Orchestration
+  - Autonomy
+---
+
+## Why agent reliability matters
+
+Autonomous agents sound magical until you realize how often they hallucinate, overrun budgets, or forget key instructions. Reliability comes from engineering discipline, not just bigger models. I anchor every project to three questions:
+
+1. What objective should the agent optimize toward?
+2. Which actions can it safely take, and with what guardrails?
+3. How do we verify that the agent did what we asked?
+
+## Layering capabilities like a product
+
+The most effective teams treat agents as products with layered responsibilities:
+
+- **Cognition layer** — prompt templates, system messages, and fine-tuned policies that align the model with business goals.
+- **Memory layer** — vector stores, relational databases, and scratch pads that retain relevant context between steps.
+- **Action layer** — tool definitions, API wrappers, and deterministic code that convert intent into execution.
+
+Each layer deserves unit tests and observability. When I instrument tool calls with tracing, I can replay entire agent runs and spot brittle prompts before they reach customers.
+
+## Tooling patterns I reuse
+
+| Pattern | When to apply | Failure mode it prevents |
+| --- | --- | --- |
+| **Permissioned tool registry** | Teams with dozens of actions and rotating contributors | Accidental exposure of destructive commands |
+| **Budget broker** | Expensive API calls or GPU usage | Agents exceeding cost ceilings |
+| **Reflection loop** | High-stakes tasks with fuzzy requirements | Agents accepting incorrect intermediate answers |
+
+These patterns prevent "cascade failure" where one unexpected model response knocks the entire workflow offline.
+
+## Shipping agents with humans in the loop
+
+Autonomy does not mean absence of humans. I design stages of review:
+
+1. **Draft** — the agent prepares a plan, citing sources and assumptions.
+2. **Execute** — it runs constrained tasks, logging every decision.
+3. **Review** — a human approves, edits, or re-runs steps with additional context.
+
+The agent accelerates work while people stay accountable for outcomes.
+
+## Continuous evaluation is non-negotiable
+
+A regression suite of prompts is my best friend. I schedule daily runs across edge cases and compare embeddings of the responses. When drift appears, I know whether to update prompts, retrain a model, or adjust tools. Without automated evaluation, agent projects degrade quietly until they fail loudly.
+
+The takeaway: agents become reliable when you craft them like software systems. Invest in architecture, instrumentation, and feedback loops before chasing flashier demos.

--- a/content/blog/context-engineering-playbook.md
+++ b/content/blog/context-engineering-playbook.md
@@ -1,0 +1,56 @@
+---
+title: Context Engineering for High-Signal Prompts
+description: Techniques I use to feed language models the right evidence and avoid noisy prompt payloads.
+publishedAt: 2024-07-18
+tags:
+  - Context Engineering
+  - Prompt Design
+  - LLMs
+---
+
+## Start by framing the user intent
+
+Context engineering is not about packing every scrap of data into the prompt. It's about selecting the right evidence to satisfy the user's job to be done. I start by rewriting the request as:
+
+> *"The assistant must help the user accomplish X by deciding Y while respecting constraints Z."*
+
+When the intent is crisp, the rest of the pipeline falls into place.
+
+## Build context ladders
+
+I design "ladders" of context where each rung adds fidelity:
+
+1. **Global policies** — governance, tone, legal guardrails.
+2. **Session state** — what happened in this conversation so far.
+3. **Task-specific documents** — knowledge bases, code snippets, analytics.
+4. **Adaptive retrieval** — targeted lookups triggered only when needed.
+
+By making each rung optional, the system avoids sending redundant information when the answer is obvious.
+
+## Maintain a context budget
+
+Large context windows are still finite. I run a budgeting function that tracks token usage before building the final prompt. If the payload exceeds the budget, the function prunes low-signal sections first, then compresses with extractive summaries, and finally falls back to retrieval on demand.
+
+```ts
+const budget = new TokenBudget(16000);
+budget.add(globalPolicies);
+budget.add(sessionState);
+budget.add(taskDocs, { priority: "high" });
+
+if (!budget.fits()) {
+  budget.pruneByPriority();
+  budget.compressWithSummaries();
+}
+```
+
+## Traceability beats cleverness
+
+Stakeholders need to know why the model answered a question. I tag every snippet with a citation ID and include those IDs in the response. When a human reviews the output, they can trace each sentence to its source. That transparency builds trust faster than any fancy prompt hack.
+
+## Iterate with telemetry
+
+- Log the full prompt, response, cost, and latency for every call (with sensitive data redacted).
+- Cluster low-rated answers to spot systemic gaps in your context sources.
+- Run A/B tests on retrieval strategies to validate improvements before rolling them out.
+
+Treat context engineering as a lifecycle. When you iterate continuously, your assistants stay grounded, helpful, and compliant even as your knowledge base evolves.

--- a/content/blog/git-ops-for-solo-creators.md
+++ b/content/blog/git-ops-for-solo-creators.md
@@ -1,0 +1,51 @@
+---
+title: Git Ops Habits for Solo Creators
+description: Lightweight workflows that keep personal projects shippable without corporate tooling.
+publishedAt: 2024-08-01
+tags:
+  - Git
+  - Productivity
+  - Indie Makers
+---
+
+## Treat your repo like a product backlog
+
+Even when I'm the only contributor, I keep a `CHANGELOG.md` and a running list of TODO issues. Every commit references one of those TODOs. This habit keeps context alive when I return after a few weeks and can't remember why a branch exists.
+
+## Branch off main, merge fast
+
+- Create a branch per feature or bug fix.
+- Keep branches under ~150 lines of diff.
+- Merge or delete within a week.
+
+Small, frequent merges reduce the cognitive load of rebasing and make it safe to experiment.
+
+## Automate boring checks
+
+Git hooks are your best friend:
+
+```bash
+#!/bin/sh
+pnpm lint
+pnpm test
+```
+
+Drop that into `.git/hooks/pre-commit` and even solo projects gain a safety net. Pair hooks with GitHub Actions or simple cron jobs to run integration tests nightly.
+
+## Document decisions in commit messages
+
+A good commit message answers three questions:
+
+1. **What changed?** Summarize in 50 characters.
+2. **Why?** Provide a sentence or two of context in the body.
+3. **How to verify?** Mention the test or manual step.
+
+When I follow this format, I can roll back confidently because every commit feels like a mini change request.
+
+## Make releases feel real
+
+- Tag stable commits with semantic versions.
+- Generate release notes from the changelog.
+- Publish small updates regularly to build momentum.
+
+Consistent Git discipline is the secret to making side projects feel like shipping products, even if you're the only person pushing commits.

--- a/content/blog/ibm-adk-workflow-blueprint.md
+++ b/content/blog/ibm-adk-workflow-blueprint.md
@@ -1,0 +1,47 @@
+---
+title: Shipping Enterprise Automations with IBM ADK
+description: Lessons learned from using IBM's Automation Development Kit to standardize document-centric workflows.
+publishedAt: 2024-07-05
+tags:
+  - IBM ADK
+  - Automation
+  - Enterprise
+---
+
+## Understand the problem before touching the toolkit
+
+IBM's Automation Development Kit (ADK) is a powerhouse for building document-intensive automations, but it expects clarity. I always document:
+
+- The exact document types involved and their variability.
+- The business rules a human follows today.
+- The downstream systems that consume structured output.
+
+This discovery phase prevents rework when the first training set hits the pipeline.
+
+## Model the pipeline as modular services
+
+ADK encourages separating concerns across stages such as ingestion, classification, extraction, and verification. I map each stage to a containerized microservice. That lets me iterate on extraction without redeploying ingestion, and it gives operations teams clearer ownership.
+
+```
+[Capture] -> [Normalize] -> [Classify] -> [Extract] -> [Validate] -> [Publish]
+```
+
+Each block becomes an independently testable unit with its own CI checks.
+
+## Training accelerators worth adopting
+
+- **Labeling studio** — invest in tight feedback loops between subject matter experts and annotators. The integrated labeling tools reduce context switching.
+- **Reusable skill packs** — IBM ships pre-trained assets for invoices, claims, and KYC docs. Customize them rather than starting from scratch.
+- **Confidence scoring dashboards** — business stakeholders understand sliders better than probability distributions. Translate scores into thresholds they can tweak.
+
+## Governance is not optional
+
+Regulated industries demand auditable trails. I route every configuration change through Git, attach change requests to Jira tickets, and export ADK run logs to a SIEM. When auditors arrive, we have a reproducible story for every model decision.
+
+## Hand-off playbook
+
+1. Document the end-to-end architecture with swimlanes for business and technical actors.
+2. Provide runbooks for scaling clusters, retraining models, and rotating credentials.
+3. Schedule quarterly capability reviews with operations teams to surface drift early.
+
+The ADK shines when paired with disciplined engineering. Treat it as a platform, not a magic wand, and you'll ship dependable automations that make auditors and line-of-business leaders equally happy.

--- a/content/blog/linux-automation-toolkit.md
+++ b/content/blog/linux-automation-toolkit.md
@@ -1,0 +1,56 @@
+---
+title: Linux Automation Toolkit for Builders
+description: My go-to collection of shell patterns, system services, and observability tricks for reliable automation.
+publishedAt: 2024-08-12
+tags:
+  - Linux
+  - Automation
+  - DevOps
+---
+
+## Start with predictable environments
+
+I rely on declarative provisioning with tools like Ansible or Nix to eliminate snowflake servers. Even when I'm hacking on a Raspberry Pi, I keep an inventory file that defines packages, systemd units, and environment variables. Rebuilding a machine becomes a single command, not a nightlong archaeology dig.
+
+## Compose automations with systemd
+
+Systemd timers beat cron for anything that deserves observability. A typical backup unit looks like this:
+
+```ini
+[Unit]
+Description=Sync project snapshots to object storage
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/backup-projects
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Pair it with a timer and you get native logging, restart policies, and dependency management.
+
+## Instrument everything
+
+- Use `journalctl -u <service>` to inspect execution history.
+- Ship logs to Loki or Elasticsearch for long-term retention.
+- Wrap critical scripts with `set -euo pipefail` and structured logging so alerts contain actionable data.
+
+## Shell patterns that scale
+
+```bash
+set -euo pipefail
+IFS=$'\n\t'
+log() { printf '%s %s\n' "$(date --iso-8601=seconds)" "$*"; }
+trap 'log "error on line $LINENO"' ERR
+```
+
+These four lines have saved me from countless silent failures. Combine them with `shellcheck` in CI and you catch bugs before they hit production.
+
+## Build feedback loops
+
+- Monitor resource usage with `btop` or `glances` during load tests.
+- Wire Prometheus exporters into long-running services.
+- Document runbooks that explain how to validate an automation after changes.
+
+Linux remains the most flexible automation platform I know. With a small toolkit of reproducible provisioning, systemd-powered scheduling, and obsessive observability, you can trust your scripts to run long after you forget about them.


### PR DESCRIPTION
## Summary
- import Next.js Link on the homepage
- add a "Visit Blog" button to the hero CTA group that navigates to /blog

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7e9030e58832e95a3ae476870ecf7