### PR TITLE
Refactor skills section with reusable cards

### DIFF
--- a/app/components/SkillCard.tsx
+++ b/app/components/SkillCard.tsx
@@ -1,0 +1,42 @@
+import { IconType } from "react-icons";
+
+export type Skill = {
+  name: string;
+  icon: IconType;
+};
+
+type SkillCardProps = {
+  title: string;
+  skills: Skill[];
+};
+
+const SkillCard = ({ title, skills }: SkillCardProps) => {
+  return (
+    <div className="group rounded-2xl border border-white/10 bg-white/10 p-6 shadow-lg backdrop-blur-sm transition-transform transition-shadow duration-300 hover:-translate-y-1 hover:shadow-2xl dark:bg-white/5">
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="text-xl font-semibold text-blue-100">{title}</h3>
+        <span className="h-1 w-14 rounded-full bg-gradient-to-r from-indigo-200 via-blue-200 to-cyan-200" />
+      </div>
+      <div className="flex flex-wrap gap-3">
+        {skills.map((skill) => {
+          const Icon = skill.icon;
+          return (
+            <span
+              key={`${title}-${skill.name}`}
+              className="flex items-center gap-2 rounded-full bg-white/20 px-3 py-2 text-sm font-medium text-white shadow-sm transition-colors duration-200 group-hover:bg-white/30"
+            >
+              <Icon
+                aria-label={`${skill.name} icon`}
+                role="img"
+                className="text-lg drop-shadow"
+              />
+              <span>{skill.name}</span>
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default SkillCard;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,15 +1,95 @@
 import {
-  FaGithub,
-  FaLinkedin,
-  FaMedium,
-  FaLaptopCode,
+  FaBrain,
   FaChalkboardTeacher,
   FaChess,
+  FaCloud,
+  FaDatabase,
+  FaDocker,
+  FaGithub,
+  FaGitAlt,
+  FaLanguage,
+  FaLayerGroup,
+  FaLaptopCode,
+  FaLinkedin,
+  FaMedium,
+  FaNetworkWired,
+  FaNodeJs,
+  FaProjectDiagram,
+  FaRobot,
+  FaSearch,
+  FaEye,
+  FaLinux,
 } from "react-icons/fa";
-import { SiLeetcode } from "react-icons/si";
+import {
+  SiAnsible,
+  SiDjango,
+  SiElasticsearch,
+  SiFastapi,
+  SiFlask,
+  SiGraphql,
+  SiLeetcode,
+  SiSpringboot,
+} from "react-icons/si";
+import { GiArtificialIntelligence } from "react-icons/gi";
+import SkillCard, { Skill } from "./components/SkillCard";
 import Image from "next/image";
 import Link from "next/link";
 import pp from "./images/dp.jpeg";
+
+type SkillCategory = {
+  title: string;
+  skills: Skill[];
+};
+
+const skillCategories: SkillCategory[] = [
+  {
+    title: "AI Engineering",
+    skills: [
+      { name: "Machine Learning", icon: FaBrain },
+      { name: "Deep Learning", icon: GiArtificialIntelligence },
+      { name: "Generative AI", icon: FaRobot },
+      { name: "NLP", icon: FaLanguage },
+      { name: "Computer Vision", icon: FaEye },
+      { name: "AI Search", icon: FaSearch },
+      { name: "Multimodal Models", icon: FaLayerGroup },
+      { name: "Agents", icon: FaProjectDiagram },
+      { name: "MCP", icon: FaNetworkWired },
+    ],
+  },
+  {
+    title: "Backend Development",
+    skills: [
+      { name: "Spring Boot", icon: SiSpringboot },
+      { name: "Django", icon: SiDjango },
+      { name: "Flask", icon: SiFlask },
+      { name: "NodeJS", icon: FaNodeJs },
+      { name: "FastAPI", icon: SiFastapi },
+    ],
+  },
+  {
+    title: "Database Systems",
+    skills: [
+      { name: "SQL", icon: FaDatabase },
+      { name: "NoSQL", icon: FaDatabase },
+      { name: "GraphQL", icon: SiGraphql },
+      { name: "Elastic", icon: SiElasticsearch },
+      { name: "Milvus", icon: FaProjectDiagram },
+      { name: "Weaviate", icon: FaProjectDiagram },
+      { name: "Chroma", icon: FaProjectDiagram },
+      { name: "Neo4j", icon: FaNetworkWired },
+    ],
+  },
+  {
+    title: "DevOps",
+    skills: [
+      { name: "Linux", icon: FaLinux },
+      { name: "Git", icon: FaGitAlt },
+      { name: "Docker", icon: FaDocker },
+      { name: "OpenShift", icon: FaCloud },
+      { name: "Ansible", icon: SiAnsible },
+    ],
+  },
+];
 
 export default function Page() {
   return (
@@ -447,119 +527,14 @@ export default function Page() {
             My Skills & Expertise
           </h2>
 
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
-            <div className="bg-white/10 backdrop-blur-sm p-6 rounded-lg">
-              <h3 className="text-xl font-semibold mb-3 text-blue-200">
-                AI Engineering
-              </h3>
-              <div className="flex flex-wrap gap-2">
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  Machine Learning
-                </span>
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  Deep Learning
-                </span>
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  Generative AI
-                </span>
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  NLP
-                </span>
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  Computer Vision
-                </span>
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  AI Search
-                </span>
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  Multimodal Models
-                </span>
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  Agents
-                </span>
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  MCP
-                </span>
-              </div>
-            </div>
-
-            <div className="bg-white/10 backdrop-blur-sm p-6 rounded-lg">
-              <h3 className="text-xl font-semibold mb-3 text-blue-200">
-                Backend Development
-              </h3>
-              <div className="flex flex-wrap gap-2">
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  Spring Boot
-                </span>
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  Django
-                </span>
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  Flask
-                </span>
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  NodeJS
-                </span>
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  Fast API
-                </span>
-              </div>
-            </div>
-
-            <div className="bg-white/10 backdrop-blur-sm p-6 rounded-lg">
-              <h3 className="text-xl font-semibold mb-3 text-blue-200">
-                Database Systems
-              </h3>
-              <div className="flex flex-wrap gap-2">
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  SQL
-                </span>
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  NoSQL
-                </span>
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  GraphQL
-                </span>
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  Elastic
-                </span>
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  Milvus
-                </span>
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  Weaviate
-                </span>
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  Chroma
-                </span>
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  Neo4j
-                </span>
-              </div>
-            </div>
-
-            <div className="bg-white/10 backdrop-blur-sm p-6 rounded-lg">
-              <h3 className="text-xl font-semibold mb-3 text-blue-200">
-                DevOps
-              </h3>
-              <div className="flex flex-wrap gap-2">
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  Linux
-                </span>
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  Git
-                </span>
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  Docker
-                </span>
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  OpenShift
-                </span>
-                <span className="bg-white/20 px-3 py-1 rounded-full text-sm">
-                  Ansible
-                </span>
-              </div>
-            </div>
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
+            {skillCategories.map((category) => (
+              <SkillCard
+                key={category.title}
+                title={category.title}
+                skills={category.skills}
+              />
+            ))}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- replace the hardcoded skills grid with a data-driven structure rendered through a reusable SkillCard component
- add modern styling and icon-labeled pills for each skill to keep the section responsive and accessible

## Testing
- pnpm lint *(fails: Command "lint" not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b01e3391c832e8583a8772456c208)